### PR TITLE
AWS SDK v3

### DIFF
--- a/fluent-plugin-rds-pgsql-log.gemspec
+++ b/fluent-plugin-rds-pgsql-log.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "fluentd", ">= 0.14.0", "< 2"
-  spec.add_dependency "aws-sdk", "~> 2"
+  spec.add_dependency "aws-sdk", "~> 3"
 
   spec.add_development_dependency "bundler", "~> 1.7"
 end


### PR DESCRIPTION
This was the easiest way to upgrade, but potentially only the `aws-sdk-rds` gem should be a dependency.