### PR TITLE
Use record time instead of current time

### DIFF
--- a/test/plugin/test_in_rds_pgsql.rb
+++ b/test/plugin/test_in_rds_pgsql.rb
@@ -10,7 +10,7 @@ class RdsPgsqlLogInputTest < Test::Unit::TestCase
     secret_access_key: 'dummy_secret_access_key',
     region: 'ap-northeast-1',
     db_instance_identifier: 'test-postgres-id',
-    refresh_interval: 30,
+    refresh_interval: 2,
     pos_file: 'pgsql-log-pos.dat',
   }
 
@@ -46,6 +46,40 @@ class RdsPgsqlLogInputTest < Test::Unit::TestCase
     assert_equal 'ap-northeast-1', d.instance.region
     assert_equal 'test-postgres-id', d.instance.db_instance_identifier
     assert_equal 'pgsql-log-pos.dat', d.instance.pos_file
-    assert_equal 30, d.instance.refresh_interval
+    assert_equal 2, d.instance.refresh_interval
+  end
+
+  def test_get_log_files
+    use_iam_role
+    d = create_driver
+
+    aws_client_stub = Aws::RDS::Client.new(stub_responses: {
+      describe_db_log_files: {
+        describe_db_log_files: [
+          {
+            log_file_name: 'db.log',
+            last_written: 123,
+            size: 123
+          }
+        ],
+        marker: 'marker'
+      },
+      download_db_log_file_portion: {
+        log_file_data: "2019-01-26 22:10:20 UTC::@:[129155]:LOG:some db log",
+        marker: 'marker',
+        additional_data_pending: false
+      }
+    })
+
+    d.instance.instance_variable_set(:@rds, aws_client_stub)
+
+    d.run(timeout: 3, expect_emits: 1)
+
+    events = d.events
+    assert_equal(events[0][1].iso8601, "2019-01-26T22:10:20Z")
+    assert_equal(events[0][2]["pid"], '129155')
+    assert_equal(events[0][2]["message_level"], 'LOG')
+    assert_equal(events[0][2]["message"], 'some db log')
+    assert_equal(events[0][2]["log_file_name"], 'db.log')
   end
 end


### PR DESCRIPTION
Use the time the line was emitted instead of the time when the line was parsed.