### PR TITLE
Fix iteration code

### DIFF
--- a/lib/fluent/plugin/in_rds_pgsql_log.rb
+++ b/lib/fluent/plugin/in_rds_pgsql_log.rb
@@ -50,7 +50,7 @@ class Fluent::Plugin::RdsPgsqlLogInput < Fluent::Plugin::Input
     # pos file touch
     File.open(@pos_file, File::RDWR|File::CREAT).close
 
-    timer_execute(:poll_logs, @refresh_interval, repeat: true, &method(:input))
+    schedule_next
   end
 
   def shutdown
@@ -61,9 +61,25 @@ class Fluent::Plugin::RdsPgsqlLogInput < Fluent::Plugin::Input
 
   def input
     get_and_parse_posfile
-    log_files = get_logfile_list
-    get_logfile(log_files)
+
+    log_files = get_first_unseen_log_file
+    return schedule_next if log_files.empty?
+
+    additional_data_pending = read_and_forward(log_files[0])
+
     put_posfile
+
+    # Directly schedule next fetch if additional data is pending
+    return schedule_next(1) if additional_data_pending
+
+    schedule_next
+  rescue => e
+    log.warn "input fetching error occurred: #{e.message}"
+    schedule_next
+  end
+
+  def schedule_next(interval = @refresh_interval)
+    timer_execute(:poll_logs, interval, repeat: false, &method(:input))
   end
 
   def has_iam_role?
@@ -121,61 +137,58 @@ class Fluent::Plugin::RdsPgsqlLogInput < Fluent::Plugin::Input
     end
   end
 
-  def get_logfile_list
+  def get_first_unseen_log_file
     begin
       log.debug "get logfile-list from rds: db_instance_identifier=#{@db_instance_identifier}, pos_last_written_timestamp=#{@pos_last_written_timestamp}"
-      @rds.describe_db_log_files(
+      response = @rds.describe_db_log_files(
         db_instance_identifier: @db_instance_identifier,
         file_last_written: @pos_last_written_timestamp,
-        max_records: 10,
+        max_records: 1,
       )
+
+      response[:describe_db_log_files]
     rescue => e
       log.warn "RDS Client describe_db_log_files error occurred: #{e.message}"
     end
   end
 
-  def get_logfile(log_files)
+  def read_and_forward(log_file)
     begin
-      log_files.each do |log_file|
-        log_file.describe_db_log_files.each do |item|
-          # save maximum written timestamp value
-          @pos_last_written_timestamp = item[:last_written] if @pos_last_written_timestamp < item[:last_written]
+      # log file download
+      log_file_name = log_file[:log_file_name]
+      marker = @pos_info.has_key?(log_file_name) ? @pos_info[log_file_name] : "0"
 
-          # log file download
-          log_file_name = item[:log_file_name]
-          marker = @pos_info.has_key?(log_file_name) ? @pos_info[log_file_name] : "0"
+      log.debug "download log from rds: log_file_name=#{log_file_name}, marker=#{marker}"
+      log_file_portion = @rds.download_db_log_file_portion(
+        db_instance_identifier: @db_instance_identifier,
+        log_file_name: log_file_name,
+        marker: marker,
+      )
+      raw_records = get_logdata(log_file_portion, log_file_name)
 
-          log.debug "download log from rds: log_file_name=#{log_file_name}, marker=#{marker}"
-          logs = @rds.download_db_log_file_portion(
-            db_instance_identifier: @db_instance_identifier,
-            log_file_name: log_file_name,
-            marker: marker,
-          )
-          raw_records = get_logdata(logs)
-
-          #emit
-          parse_and_emit(raw_records, log_file_name) unless raw_records.nil?
-        end
+      unless raw_records.nil?
+        # save maximum written timestamp value
+        last_seen_record_time = parse_and_emit(raw_records, log_file_name)
+        @pos_last_written_timestamp = timestamp_with_ms(last_seen_record_time) unless last_seen_record_time.nil?
       end
+
+      additional_data_pending = log_file_portion.additional_data_pending
     rescue => e
       log.warn e.message
     end
   end
 
-  def get_logdata(logs)
-    log_file_name = logs.context.params[:log_file_name]
-    raw_records = []
-    begin
-      logs.each do |log|
-        # save got line's marker
-        @pos_info[log_file_name] = log.marker
+  def timestamp_with_ms(time)
+    (Time.parse(time).to_f * 1000).to_i
+  end
 
-        raw_records += log.log_file_data.split("\n")
-      end
-    rescue => e
-      log.warn e.message
-    end
-    return raw_records
+  def get_logdata(log_file_portion, log_file_name)
+    # save got line's marker
+    @pos_info[log_file_name] = log_file_portion.marker
+
+    log_file_portion.log_file_data.split("\n")
+  rescue => e
+    log.warn e.message
   end
 
   def event_time_of_row(record)
@@ -184,6 +197,8 @@ class Fluent::Plugin::RdsPgsqlLogInput < Fluent::Plugin::Input
   end
 
   def parse_and_emit(raw_records, log_file_name)
+    last_seen_record_time = nil
+
     begin
       log.debug "raw_records.count: #{raw_records.count}"
       record = nil
@@ -199,6 +214,7 @@ class Fluent::Plugin::RdsPgsqlLogInput < Fluent::Plugin::Input
           router.emit(@tag, event_time_of_row(record), record) unless record.nil?
 
           # set a record
+          last_seen_record_time = line_match[:time]
           record = {
             "time" => line_match[:time],
             "host" => line_match[:host],
@@ -216,17 +232,7 @@ class Fluent::Plugin::RdsPgsqlLogInput < Fluent::Plugin::Input
     rescue => e
       log.warn e.message
     end
-  end
 
-  class TimerWatcher < Coolio::TimerWatcher
-    def initialize(interval, repeat, &callback)
-      @callback = callback
-      on_timer # first call
-      super(interval, repeat)
-    end
-
-    def on_timer
-      @callback.call
-    end
+    last_seen_record_time
   end
 end

--- a/lib/fluent/plugin/in_rds_pgsql_log.rb
+++ b/lib/fluent/plugin/in_rds_pgsql_log.rb
@@ -169,7 +169,13 @@ class Fluent::Plugin::RdsPgsqlLogInput < Fluent::Plugin::Input
       unless raw_records.nil?
         # save maximum written timestamp value
         last_seen_record_time = parse_and_emit(raw_records, log_file_name)
-        @pos_last_written_timestamp = timestamp_with_ms(last_seen_record_time) unless last_seen_record_time.nil?
+        unless last_seen_record_time.nil?
+          @pos_last_written_timestamp = timestamp_with_ms(last_seen_record_time)
+        else
+          @pos_last_written_timestamp += 1
+        end
+      else
+        @pos_last_written_timestamp += 1
       end
 
       additional_data_pending = log_file_portion.additional_data_pending

--- a/test/plugin/test_in_rds_pgsql.rb
+++ b/test/plugin/test_in_rds_pgsql.rb
@@ -156,7 +156,7 @@ class RdsPgsqlLogInputTest < Test::Unit::TestCase
     assert_equal(describe_db_log_files_params[0], {:db_instance_identifier=>"test-postgres-id", :file_last_written=>0, :max_records=>1})
     assert_equal(download_db_log_file_portion_params[0], {:db_instance_identifier=>"test-postgres-id", :log_file_name=>"db.log", :marker=>"0"})
 
-    assert_equal(describe_db_log_files_params[1], {:db_instance_identifier=>"test-postgres-id", :file_last_written=>1548540620000, :max_records=>1})
+    assert_equal(describe_db_log_files_params[1], {:db_instance_identifier=>"test-postgres-id", :file_last_written=>1548540620001, :max_records=>1})
     assert_equal(download_db_log_file_portion_params[1], {:db_instance_identifier=>"test-postgres-id", :log_file_name=>"db.log", :marker=>"10"})
 
     events = d.events

--- a/test/plugin/test_in_rds_pgsql.rb
+++ b/test/plugin/test_in_rds_pgsql.rb
@@ -19,7 +19,13 @@ class RdsPgsqlLogInputTest < Test::Unit::TestCase
   end
 
   def create_driver(conf = DEFAULT_CONFIG)
-    Fluent::Test::Driver::Input.new(Fluent::Plugin::RdsPgsqlLogInput).configure(parse_config conf)
+    d = Fluent::Test::Driver::Input.new(Fluent::Plugin::RdsPgsqlLogInput).configure(parse_config conf)
+
+    # Cleanup old pos_file
+    pos_file = d.instance.pos_file
+    File.delete(pos_file) if File.exist?(pos_file)
+
+    d
   end
 
   def iam_info_url
@@ -82,5 +88,98 @@ class RdsPgsqlLogInputTest < Test::Unit::TestCase
     assert_equal(events[0][2]["message_level"], 'LOG')
     assert_equal(events[0][2]["message"], 'some db log')
     assert_equal(events[0][2]["log_file_name"], 'db.log')
+  end
+
+  def test_iterating
+    use_iam_role
+    d = create_driver
+
+    aws_client_stub = Aws::RDS::Client.new(stub_responses: true)
+
+    describe_db_log_files_attempt = 0
+    describe_db_log_files_params = []
+    aws_client_stub.stub_responses(:describe_db_log_files, -> (context) {
+      describe_db_log_files_params << context.params
+      describe_db_log_files_attempt += 1
+
+      if describe_db_log_files_attempt == 1
+        return {
+          describe_db_log_files: [
+            {
+              log_file_name: 'db.log',
+              last_written: 123,
+              size: 123
+            }
+          ]
+        }
+      end
+
+      {
+        describe_db_log_files: [
+          {
+            log_file_name: 'db.log',
+            last_written: 456,
+            size: 123
+          }
+        ]
+      }
+    })
+
+    download_db_log_file_portion_attempt = 0
+    download_db_log_file_portion_params = []
+    aws_client_stub.stub_responses(:download_db_log_file_portion, -> (context) {
+      download_db_log_file_portion_params << context.params
+      download_db_log_file_portion_attempt += 1
+
+      if download_db_log_file_portion_attempt == 1
+        return {
+          log_file_data: "2019-01-26 22:10:20 UTC::@:[129155]:LOG:some db log",
+          marker: '10',
+          additional_data_pending: true
+        }
+      end
+
+      {
+        log_file_data: "2019-01-26 22:15:20 UTC::@:[129155]:LOG:some later db log",
+        marker: '20',
+        additional_data_pending: false
+      }
+    })
+
+    d.instance.instance_variable_set(:@rds, aws_client_stub)
+
+    d.run(timeout: 3, expect_emits: 2)
+
+    assert_equal(describe_db_log_files_attempt, 2)
+    assert_equal(download_db_log_file_portion_attempt, 2)
+
+    assert_equal(describe_db_log_files_params[0], {:db_instance_identifier=>"test-postgres-id", :file_last_written=>0, :max_records=>1})
+    assert_equal(download_db_log_file_portion_params[0], {:db_instance_identifier=>"test-postgres-id", :log_file_name=>"db.log", :marker=>"0"})
+
+    assert_equal(describe_db_log_files_params[1], {:db_instance_identifier=>"test-postgres-id", :file_last_written=>1548540620000, :max_records=>1})
+    assert_equal(download_db_log_file_portion_params[1], {:db_instance_identifier=>"test-postgres-id", :log_file_name=>"db.log", :marker=>"10"})
+
+    events = d.events
+    assert_equal(events[0][1].inspect, "2019-01-26 22:10:20.000000000 +0000")
+    assert_equal(events[0][2], {
+      "database"=>"",
+      "host"=>"",
+      "log_file_name"=>"db.log",
+      "message"=>"some db log",
+      "message_level"=>"LOG",
+      "pid"=>"129155",
+      "time"=>"2019-01-26 22:10:20 UTC",
+      "user"=>""
+    })
+    assert_equal(events[1][2], {
+      "database"=>"",
+      "host"=>"",
+      "log_file_name"=>"db.log",
+      "message"=>"some later db log",
+      "message_level"=>"LOG",
+      "pid"=>"129155",
+      "time"=>"2019-01-26 22:15:20 UTC",
+      "user"=>""
+    })
   end
 end


### PR DESCRIPTION
It seemed that the iteration code wasn't working correctly as it was always setting the `last_written` timestamp as the next starting point, even before the entire changes between current position and `last_written` timestamp had been downloaded.

This now changes the iteration logic to always always remember the time of the last seen log line and then request the next file from AWS with more data, which has been written since then.

This also changes the looping logic to not loop strictly every 30s, but only restarts the timer once the current portion has been fetched. This should reduce the pressure on the AWS API, especially when fetching logs from multiple instances as calls should now be more randomly distributed.

To handle log surges, the next iteration is scheduled to start in 1s (instead of `refresh_interval`) to be able to keep up with logs. The code could also iterate directly on the file, but then new logic around keeping the pos file up-to-date would need to be introduced, so this should be good enough.